### PR TITLE
Fix eval issue in haul

### DIFF
--- a/src/messages/bundleBuilt.js
+++ b/src/messages/bundleBuilt.js
@@ -29,20 +29,9 @@ module.exports = ({
   assetsPath?: string,
   bundlePath?: string,
 }) => {
-  const buildStats = stats.toJson({ timing: true });
-  let heading = '';
-  if (buildStats.time) {
-    heading = buildStats.hasWarnings()
-      ? chalk.yellow('Built with warnings')
-      : `Built successfully in ${(buildStats.time / 1000).toFixed(2)}s!`;
-  } else {
-    heading += '\n';
-    for (let i = 0; i < buildStats.children.length; i++) {
-      heading += buildStats.children[i].warnings.length > 0
-        ? chalk.yellow('Built with warnings\n')
-        : `Built successfully in ${(buildStats.children[i].time / 1000).toFixed(2)}s!\n`;
-    }
-  }
+  const heading = stats.hasWarnings()
+    ? chalk.yellow('Built with warnings')
+    : `Built successfully in ${(getBuildTime(stats) / 1000).toFixed(2)}s!`;
 
   if (assetsPath && bundlePath) {
     return dedent`
@@ -57,7 +46,7 @@ module.exports = ({
 
   return dedent`
     ${heading}
-    ${warnings.length ? `\n${warnings.join('\n\n')}\n` : ''}
+
     You can now run the app on ${device}\n
   `;
 };

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -22,9 +22,11 @@ let extraPlatforms = [];
 let extraProvidesModuleNodeModules = [];
 const rnCliConfigPath = path.resolve(directory, 'rn-cli.config.js');
 if (fs.existsSync(rnCliConfigPath)) {
-  const rnCliConfig = require(rnCliConfigPath); 
+  const rnCliConfig = require(rnCliConfigPath);
   extraPlatforms = rnCliConfig.getPlatforms();
-  extraProvidesModuleNodeModules = rnCliConfig.getProvidesModuleNodeModules().reverse();
+  extraProvidesModuleNodeModules = rnCliConfig
+    .getProvidesModuleNodeModules()
+    .reverse();
 }
 
 const PLATFORMS = ['ios', 'android', ...extraPlatforms];
@@ -143,9 +145,10 @@ const getDefaultConfig = ({
         dev
           ? [
               new webpack.HotModuleReplacementPlugin(),
-              new webpack.EvalSourceMapDevToolPlugin({
-                module: true,
-              }),
+              // TODO: remove EvalSourceMapDevToolPlugin to prevent CSP errors
+              // new webpack.EvalSourceMapDevToolPlugin({
+              //   module: true,
+              // }),
               new webpack.NamedModulesPlugin(),
             ]
           : [
@@ -167,8 +170,8 @@ const getDefaultConfig = ({
               new webpack.optimize.UglifyJsPlugin({
                 /**
                  * By default, uglify only minifies *.js files
-                 * We need to use the plugin to configure *.bundle (Android, iOS - development) 
-                 * and *.jsbundle (iOS - production) to get minified. 
+                 * We need to use the plugin to configure *.bundle (Android, iOS - development)
+                 * and *.jsbundle (iOS - production) to get minified.
                  * Also disable IE8 support as we don't need it.
                  */
                 test: /\.(js|(js)?bundle)($|\?)/i,
@@ -206,14 +209,12 @@ const getDefaultConfig = ({
          */
         new HasteResolver({
           directories: extraPlatforms.includes(platform)
-          ?
-            [...extraProvidesModuleNodeModules, 'react-native'].map((provider) => {
-              return moduleResolve(root, provider);
-            })
-          :
-            [
-              moduleResolve(root, 'react-native'),
-            ]
+            ? [...extraProvidesModuleNodeModules, 'react-native'].map(
+                provider => {
+                  return moduleResolve(root, provider);
+                }
+              )
+            : [moduleResolve(root, 'react-native')],
         }),
         /**
          * This is required by asset loader to resolve extra scales


### PR DESCRIPTION
It looks like the EvalSourceMapDevToolPlugin was creating the errors you were seeing in haul. I was able to fix it by removing the plugin for now. We might be able to do something better by parsing the webpack config and respecting the devtool flag instead of what haul is doing.

I reverted the change to bundleBuilt because I couldn't figure out what was needed there.

I created this PR mostly for you to see the fix, you don't really need to merge.